### PR TITLE
Fix text overflow in stats page cards

### DIFF
--- a/app/app/stats/page.tsx
+++ b/app/app/stats/page.tsx
@@ -335,8 +335,8 @@ export default function StatsPage() {
                             </div>
                             <div className="flex-1 min-w-0">
                               <div className="font-semibold text-gray-900 truncate text-sm">{l.name}</div>
-                              <div className="text-xs text-gray-500 mb-2 break-words">{inList.length} kelime</div>
-                              <div className="flex flex-wrap items-center gap-2">
+                              <div className="text-xs text-gray-500 mb-2 break-all">{inList.length} kelime</div>
+                              <div className="flex flex-wrap items-center gap-2 min-w-0">
                                 <Badge variant="secondary" className="text-xs whitespace-nowrap">
                                   {learnedCount} öğrenildi
                                 </Badge>

--- a/components/quick-actions.tsx
+++ b/components/quick-actions.tsx
@@ -45,7 +45,7 @@ export default function QuickActions({
               <div className={`p-2 rounded-lg ${action.iconBg}`}>
                 <action.icon className={`w-4 h-4 ${action.iconColor}`} />
               </div>
-              <div>
+              <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2">
                   <span className="font-medium text-gray-900">{action.title}</span>
                   {action.priority === 'high' && (
@@ -59,7 +59,7 @@ export default function QuickActions({
                     </Badge>
                   )}
                 </div>
-                <p className="text-sm text-gray-600">{action.description}</p>
+                <p className="text-sm text-gray-600 break-words">{action.description}</p>
               </div>
             </div>
             <Link href={action.href}>

--- a/components/stats-insights.tsx
+++ b/components/stats-insights.tsx
@@ -68,7 +68,7 @@ export default function StatsInsights({
               <div className={`p-2 rounded-lg ${insight.iconBg}`}>
                 <insight.icon className={`w-5 h-5 ${insight.iconColor}`} />
               </div>
-              <div className="flex-1">
+              <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2 mb-1">
                   <h4 className="font-semibold text-gray-900">{insight.title}</h4>
                   {insight.badge && (


### PR DESCRIPTION
The text in several card components on the /stats page was overflowing its container. This was caused by improper handling of long text and flexbox container sizing.

This commit fixes the overflow issues by applying the following changes:
- Adds `min-w-0` to flexbox containers in `stats-insights.tsx`, `quick-actions.tsx`, and `app/app/stats/page.tsx` to allow them to shrink correctly when content is long.
- Adds `break-words` and `break-all` utility classes to text elements to ensure long, unbreakable strings wrap correctly and do not overflow their parent containers.